### PR TITLE
added 2017 schedule page

### DIFF
--- a/app/helpers/icon-library.js
+++ b/app/helpers/icon-library.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+
+const {String: { htmlSafe } } = Ember;
+
+export function iconLibrary([iconKey]) {
+  let icons =  {
+    'workshop': '<svg width="11px" height="23px" viewBox="0 0 11 23" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><!-- Generator: Sketch 44.1 (41455) - http://www.bohemiancoding.com/sketch --><desc>Created with Sketch.</desc><defs></defs><g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="Group-9" transform="translate(0.000000, 2.000000)" stroke="#FFFFFF" stroke-width="3"><path d="M10.65625,0 C7.21875,0.678571429 5.5,1.69642857 5.5,3.05357143 C5.5,4.41071429 5.5,8.82142857 5.5,16.2857143 C8.02083333,18.0952381 9.85416667,19 11,19" id="Path-2"></path><path d="M5.15625,0 C1.71875,0.678571429 1.40324112e-16,1.69642857 0,3.05357143 C0,4.41071429 0,8.82142857 0,16.2857143 C2.52083333,18.0952381 4.35416667,19 5.5,19" id="Path-2" transform="translate(2.750000, 9.500000) scale(-1, 1) translate(-2.750000, -9.500000) "></path></g></g></svg>',
+
+    'pause': '<svg width="16px" height="20px" viewBox="0 0 16 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><!-- Generator: Sketch 44.1 (41455) - http://www.bohemiancoding.com/sketch --><desc>Created with Sketch.</desc><defs></defs><g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="square"><g id="Group-10-Copy" transform="translate(1.000000, 2.000000)" stroke="#FFFFFF" stroke-width="3"><g id="Group-8" transform="translate(0.392424, 0.305871)"><path d="M0.383116883,0.136485023 L0.383116883,15.9781576" id="Line"></path><path d="M12.6428571,0.136485023 L12.6428571,15.9781576" id="Line-Copy"></path></g></g></g></svg>',
+
+    'talk': '<svg width="31px" height="23px" viewBox="0 0 31 23" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><!-- Generator: Sketch 44.1 (41455) - http://www.bohemiancoding.com/sketch --><desc>Created with Sketch.</desc><defs></defs><g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="square"><g id="Group-8-Copy-4" transform="translate(2.000000, 2.000000)" stroke-width="3" stroke="#FFFFFF"><polyline id="Line" points="8.08278849 0.160392796 0.218453743 9.27380952 8.08278849 18.7770155"></polyline><polyline id="Line" transform="translate(22.849379, 9.468704) scale(-1, 1) translate(-22.849379, -9.468704) " points="26.7815463 0.160392796 18.9172115 9.27380952 26.7815463 18.7770155"></polyline></g></g></svg>'
+  };
+  return htmlSafe(icons[iconKey]);
+}
+
+export default Ember.Helper.helper(iconLibrary);

--- a/app/pods/components/seventeen-schedule-accordion/component.js
+++ b/app/pods/components/seventeen-schedule-accordion/component.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNameBindings: ['hasToggle:toggleable:not-toggleable'],
+  isOpen: false,
+  time: "",
+  title: "",
+  hasToggle: false,
+  click() {
+    if(this.get('hasToggle')) {
+      this.toggleProperty('isOpen');
+    }
+  }
+});

--- a/app/pods/components/seventeen-schedule-accordion/template.hbs
+++ b/app/pods/components/seventeen-schedule-accordion/template.hbs
@@ -1,0 +1,14 @@
+<div class="schedule-padding-wrap">
+  <div class="schedule-time">
+    {{time}}
+  </div>
+
+  <div class="schedule-title">
+    {{title}}
+  </div>
+  {{#if hasToggle}}
+    <div class="schedule-accordion-content {{if isOpen "showing" "hidden"}}">
+      {{yield}}
+    </div>
+  {{/if}}
+</div>

--- a/app/pods/components/seventeen-schedule-accordion/template.hbs
+++ b/app/pods/components/seventeen-schedule-accordion/template.hbs
@@ -8,8 +8,8 @@
     </div>
 
     <div class="schedule-title flex-1">
-      {{#if speaker}}<p>{{speaker}}</p>{{/if}}
-      <p>{{title}}</p>
+      <span>{{title}}</span>
+      {{#if speaker}}<h5>{{speaker}}</h5>{{/if}}
     </div>
   </div>
   {{#if hasToggle}}

--- a/app/pods/components/seventeen-schedule-accordion/template.hbs
+++ b/app/pods/components/seventeen-schedule-accordion/template.hbs
@@ -1,10 +1,16 @@
 <div class="schedule-padding-wrap">
-  <div class="schedule-time">
-    {{time}}
-  </div>
+  <div class="schedule-title-bar flex-grid">
+    <div class="schedule-icon {{icon}}">
+      {{icon-library icon}}
+    </div>
+    <div class="schedule-time flex-1">
+      {{time}}
+    </div>
 
-  <div class="schedule-title">
-    {{title}}
+    <div class="schedule-title flex-1">
+      {{#if speaker}}<p>{{speaker}}</p>{{/if}}
+      <p>{{title}}</p>
+    </div>
   </div>
   {{#if hasToggle}}
     <div class="schedule-accordion-content {{if isOpen "showing" "hidden"}}">

--- a/app/pods/components/top-menu/template.hbs
+++ b/app/pods/components/top-menu/template.hbs
@@ -29,7 +29,9 @@
     {{#link-to 'seventeen.attend' invokeAction=(action 'toggleMenu' false) tagName="h3"}}
       Attend
     {{/link-to}}
-    <h3>Schedule — Coming Soon</h3>
+    {{#link-to 'seventeen.schedule' invokeAction=(action 'toggleMenu' false) tagName="h3"}}
+      Schedule
+    {{/link-to}}
     {{#link-to 'seventeen.team' invokeAction=(action 'toggleMenu' false) tagName="h3"}}
       Team
     {{/link-to}}

--- a/app/pods/seventeen/schedule/route.js
+++ b/app/pods/seventeen/schedule/route.js
@@ -1,0 +1,110 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  setupController(controller) {
+    controller.set('talks', [
+      { time: "8.00AM - 9.00AM",
+        title: "BREAKFAST AND REGISTRATION",
+        speaker: "",
+        description: "",
+        hasToggle: false
+      },
+      { time: "9.00AM - 9.30AM",
+        title: "UNKNOWN",
+        speaker: "JEREMY FOSTER",
+        description: "You live, breath, and think JavaScript. It’s because you have a propeller brain. It’s great. You’re solving the world’s problems one node module at a time. You’re making work more productive and our personal lives more streamline. But, although I know it's heretical, there's more to life than the freaking code! So let’s have some high-level banter about the state of tech, the future of tech, and your place in the whole thing as a developer. I offer alt perspective, mild humor, inspiring life pro tips, and absolutely no cat gifs.",
+        hasToggle: true
+      },
+      { time: "10.00AM - 10.30AM",
+        title: "MAKING THE JUMP: HOW DESTOP ERA FRAMEWORKS CAN THRIVE ON MOBILE",
+        speaker: "TOM DALE",
+        description: "Today’s most popular frameworks come from a time when the world was a different place. Ember’s first rendering engine, for example, was optimized around the performance gotchas of Internet Explorer 6. IE6 has since faded into history, and smartphones with spotty connectivity and occasionally dodgy hardware have become the lowest common denominator that we must optimize for. In this talk, we’ll discuss how smartphones fundamentally change the assumptions we make about architecting applications for the web. Then, we’ll cover how we can embrace these new mobile constraints to build even better apps—for everyone. Finally, we’ll look at the techniques used by desktop-era libraries and what they’re doing to become great for the mobile web.",
+        hasToggle: true
+      },
+      { time: "10.30AM - 11.00AM",
+        title: "BREAK",
+        speaker: "MIKE & JUSTIN",
+        description: "",
+        hasToggle: false
+      },
+      { time: "11.00AM - 11.30AM",
+        title: "PERFECTING PERF: RAPID, RIGOROUS AND REPRODUCIBLE PERFORMANCE EXPERIMENTS",
+        speaker: "LON INGRAM",
+        description: "With the rise of the mobile web, speed has become crucial to success. Users won't wait around for slow-loading pages and search engines are now punishing sluggish sites. There's a wealth of ideas out there for cranking up performance, but how do you know where to start? What if you work for days to ship an optimization that doesn't really pay off? In this talk, you'll learn how to experiment and fail fast. You'll find out how to quickly and rigorously assess your optimization ideas with open source tools, and how to share your results so that others can replicate your findings.",
+        hasToggle: true
+      },
+      { time: "11.30AM - 12.00PM",
+        title: "SOLVING IMAGINARY SCALING ISSUES, AT SCALE",
+        speaker: "LAURIE VOSS",
+        description: "@ThePracticalDev on Twitter once created a fake book cover called 'Solving Imaginary Scaling Issues, at Scale'. I got carried away and came up with over 30 chapters for the book. This is a fast-paced, funny tour of the many silly things people do to solve scaling problems that don't exist, and genuine, practical advice on how to really scale, from the people who serve JavaScript developers over 2 billion downloads a week.",
+        hasToggle: true
+      },
+      { time: "12.00PM - 12.30PM",
+        title: "EMOJI, WEB COMPONENTS, AND ART",
+        speaker: "MONICA DINULESCU",
+        description: "Making art on the web is easy, if you got the right tools. HTML has styled divs. JavaScript has canvas. I have an emoji keyboard. But what if our tools were better, and making art was easier? What if there was a magical widget that transformed any word into emoji word art? Or an image into pixels, which you can then style with CSS? What if it was easy to build these tools, embed them on any sites, and give them out to people, so that they can make art? Spoilers: it is, and I’m going to tell you about it.",
+        hasToggle: true
+      },
+      { time: "12.30PM - 1.45PM",
+        title: "LUNCH",
+        speaker: "",
+        description: "",
+        hasToggle: false
+      },
+      { time: "1.45PM - 2.15PM",
+        title: "ONE DAY WE WILL ALL BE FRONT END DEVELOPERS",
+        speaker: "MICAH ADAMS",
+        description: "Front end development skills are becoming more essential as organizations continue to leverage platforms and infrastructures as services. This talk seeks to give developers with various levels of experience a perspective on where we have come so far, where we are going, and tools to navigate the new front end ecosystem.",
+        hasToggle: true
+      },
+      { time: "2.15PM - 2.45PM",
+        title: "ATOMIC DESIGN AS A MIGRATION STRATEGY",
+        speaker: "HARRISON HARNISCH",
+        description: "Atomic design is well suited for migrating web applications. Because you build complexity out of simple components, you can start small and slowly carve out your application. I'd like to share how we're migrating 6 years of development at Buffer with Atomic Design.",
+        hasToggle: true
+      },
+      { time: "2.45PM - 3.15PM",
+        title: "ICE CREAM BREAK",
+        speaker: "",
+        description: "",
+        hasToggle: false
+      },
+      { time: "3.15PM - 3.45PM",
+        title: "ALBERS AS A MILLENIAL",
+        speaker: "BILLY ROH",
+        description: "What kind of art would Josef and Anni Albers have made if they were millennials? Come learn about how to make generative interactive art with the magic of JavaScript. The audience will learn about applying colour theory with HSL, composing and generating your own patterns with SVG, and creating a sense of depth with motion and interaction.",
+        hasToggle: true
+      },
+      { time: "3.45PM - 4.15PM",
+        title: "CONVERSATIONAL ULS: TALKING TO SIRI, ALEXA, AND YOUR WEB BROWSER",
+        speaker: "SCOTT DAVIS",
+        description: "A typical user experience these days moves seamlessly between smartphones, tablets, laptops, and even smart TVs without us even thinking about it. But what if there is no screen? What if your User Interface is talking to your wrist, or talking to thin air as you walk into a room? Gartner predicts that 30% of all interactions with computers will be done with your voice by 2020. In this talk, [REDACTED] helps break down what Conversational UIs are, and how you can adopt them in your application.",
+        hasToggle: true
+      },
+      { time: "4.15PM - 4.35PM",
+        title: "BREAK",
+        speaker: "",
+        description: "",
+        hasToggle: false
+      },
+      { time: "4.35PM - 4.45PM",
+        title: "ABOUT WORKSHOPS",
+        speaker: "STEVE KINNEY",
+        description: "",
+        hasToggle: false
+      },
+      { time: "4.45PM - 5.15PM",
+        title: "THE TRUE COST OF UNMODERATED COLLABORATION: A STORY FROM THE TRENCHES",
+        speaker: "MYLES BORINS",
+        description: "Is your project prepared to deal with toxic behavior? What is your plan of action when members of your community are being harassed? Without a clear code-of-conduct and moderation guidelines you will likely spend more time discussing what to do than moderating. In the time that your projects leaders have spent coming to consensus, your community members are being attacked. While an individual leaving a project due to harassment is fairly hard to ignore, it is not as clear how many individuals decide not to get involved to avoid harassment and negative attention.",
+        hasToggle: true
+      },
+      { time: "5.15PM - 5.30PM",
+        title: "CLOSING NOTES",
+        speaker: "",
+        description: "",
+        hasToggle: false
+      },
+    ]);
+  }
+});

--- a/app/pods/seventeen/schedule/route.js
+++ b/app/pods/seventeen/schedule/route.js
@@ -11,9 +11,16 @@ export default Ember.Route.extend({
         icon: 'pause'
       },
       { time: "9.00AM - 9.30AM",
-        title: "Unknown",
+        title: "Get Your Head Outta the Cloud – Let’s Talk Tech",
         speaker: "Jeremy Foster",
         description: "You live, breath, and think JavaScript. It’s because you have a propeller brain. It’s great. You’re solving the world’s problems one node module at a time. You’re making work more productive and our personal lives more streamline. But, although I know it's heretical, there's more to life than the freaking code! So let’s have some high-level banter about the state of tech, the future of tech, and your place in the whole thing as a developer. I offer alt perspective, mild humor, inspiring life pro tips, and absolutely no cat gifs.",
+        hasToggle: true,
+        icon: 'talk'
+      },
+      { time: "9.30AM - 10.00AM",
+        title: "JavaScript Engines: How Do They Even?",
+        speaker: "F. Hinkelmann",
+        description: "Want to know how JavaScript engines work? Why is JavaScript so fast? What is just-in-time compilation? We'll look at basic and not-so-basic concepts of compilers, challenges posed by modern JavaScript, and what that means for performance. You'll learn how to write code that's fast and compiler-friendly.",
         hasToggle: true,
         icon: 'talk'
       },
@@ -26,7 +33,7 @@ export default Ember.Route.extend({
       },
       { time: "10.30AM - 11.00AM",
         title: "Break",
-        speaker: "Mike & Justin",
+        speaker: "",
         description: "",
         hasToggle: false,
         icon: 'pause'
@@ -74,7 +81,7 @@ export default Ember.Route.extend({
         icon: 'talk'
       },
       { time: "2.45PM - 3.15PM",
-        title: "Ice Cream Break",
+        title: "Break",
         speaker: "",
         description: "",
         hasToggle: false,
@@ -106,7 +113,7 @@ export default Ember.Route.extend({
         speaker: "Steve Kinney",
         description: "",
         hasToggle: false,
-        icon: 'talk'
+        icon: 'pause'
       },
       { time: "4.45PM - 5.15PM",
         title: "The True Cost of Unmoderated Collaboration: A Story from the Trenches",
@@ -120,7 +127,7 @@ export default Ember.Route.extend({
         speaker: "",
         description: "",
         hasToggle: false,
-        icon: 'pause'
+        icon: 'talk'
       },
     ]);
 

--- a/app/pods/seventeen/schedule/route.js
+++ b/app/pods/seventeen/schedule/route.js
@@ -4,107 +4,199 @@ export default Ember.Route.extend({
   setupController(controller) {
     controller.set('talks', [
       { time: "8.00AM - 9.00AM",
-        title: "BREAKFAST AND REGISTRATION",
+        title: "Breakfast and Registration",
         speaker: "",
         description: "",
-        hasToggle: false
+        hasToggle: false,
+        icon: 'pause'
       },
       { time: "9.00AM - 9.30AM",
-        title: "UNKNOWN",
-        speaker: "JEREMY FOSTER",
+        title: "Unknown",
+        speaker: "Jeremy Foster",
         description: "You live, breath, and think JavaScript. It’s because you have a propeller brain. It’s great. You’re solving the world’s problems one node module at a time. You’re making work more productive and our personal lives more streamline. But, although I know it's heretical, there's more to life than the freaking code! So let’s have some high-level banter about the state of tech, the future of tech, and your place in the whole thing as a developer. I offer alt perspective, mild humor, inspiring life pro tips, and absolutely no cat gifs.",
-        hasToggle: true
+        hasToggle: true,
+        icon: 'talk'
       },
       { time: "10.00AM - 10.30AM",
-        title: "MAKING THE JUMP: HOW DESTOP ERA FRAMEWORKS CAN THRIVE ON MOBILE",
-        speaker: "TOM DALE",
+        title: "Making the Jump: How Destop Era Frameworks can Thrive on Mobile",
+        speaker: "Tom Dale",
         description: "Today’s most popular frameworks come from a time when the world was a different place. Ember’s first rendering engine, for example, was optimized around the performance gotchas of Internet Explorer 6. IE6 has since faded into history, and smartphones with spotty connectivity and occasionally dodgy hardware have become the lowest common denominator that we must optimize for. In this talk, we’ll discuss how smartphones fundamentally change the assumptions we make about architecting applications for the web. Then, we’ll cover how we can embrace these new mobile constraints to build even better apps—for everyone. Finally, we’ll look at the techniques used by desktop-era libraries and what they’re doing to become great for the mobile web.",
-        hasToggle: true
+        hasToggle: true,
+        icon: 'talk'
       },
       { time: "10.30AM - 11.00AM",
-        title: "BREAK",
-        speaker: "MIKE & JUSTIN",
+        title: "Break",
+        speaker: "Mike & Justin",
         description: "",
-        hasToggle: false
+        hasToggle: false,
+        icon: 'pause'
       },
       { time: "11.00AM - 11.30AM",
-        title: "PERFECTING PERF: RAPID, RIGOROUS AND REPRODUCIBLE PERFORMANCE EXPERIMENTS",
-        speaker: "LON INGRAM",
+        title: "Perfecting Perf: Rapid, Rigorous and Reproducible Performance Experiments",
+        speaker: "Lon Ingram",
         description: "With the rise of the mobile web, speed has become crucial to success. Users won't wait around for slow-loading pages and search engines are now punishing sluggish sites. There's a wealth of ideas out there for cranking up performance, but how do you know where to start? What if you work for days to ship an optimization that doesn't really pay off? In this talk, you'll learn how to experiment and fail fast. You'll find out how to quickly and rigorously assess your optimization ideas with open source tools, and how to share your results so that others can replicate your findings.",
-        hasToggle: true
+        hasToggle: true,
+        icon: 'talk'
       },
       { time: "11.30AM - 12.00PM",
-        title: "SOLVING IMAGINARY SCALING ISSUES, AT SCALE",
-        speaker: "LAURIE VOSS",
+        title: "Solving Imaginary Scaling Issues, at Scale",
+        speaker: "Laurie Voss",
         description: "@ThePracticalDev on Twitter once created a fake book cover called 'Solving Imaginary Scaling Issues, at Scale'. I got carried away and came up with over 30 chapters for the book. This is a fast-paced, funny tour of the many silly things people do to solve scaling problems that don't exist, and genuine, practical advice on how to really scale, from the people who serve JavaScript developers over 2 billion downloads a week.",
-        hasToggle: true
+        hasToggle: true,
+        icon: 'talk'
       },
       { time: "12.00PM - 12.30PM",
-        title: "EMOJI, WEB COMPONENTS, AND ART",
-        speaker: "MONICA DINULESCU",
+        title: "Emoji, Web Components, and Art",
+        speaker: "Monica Dinulescu",
         description: "Making art on the web is easy, if you got the right tools. HTML has styled divs. JavaScript has canvas. I have an emoji keyboard. But what if our tools were better, and making art was easier? What if there was a magical widget that transformed any word into emoji word art? Or an image into pixels, which you can then style with CSS? What if it was easy to build these tools, embed them on any sites, and give them out to people, so that they can make art? Spoilers: it is, and I’m going to tell you about it.",
-        hasToggle: true
+        hasToggle: true,
+        icon: 'talk'
       },
       { time: "12.30PM - 1.45PM",
-        title: "LUNCH",
+        title: "Lunch",
         speaker: "",
         description: "",
-        hasToggle: false
+        hasToggle: false,
+        icon: 'pause'
       },
       { time: "1.45PM - 2.15PM",
-        title: "ONE DAY WE WILL ALL BE FRONT END DEVELOPERS",
-        speaker: "MICAH ADAMS",
+        title: "One Day We Will All Be Front End Developers",
+        speaker: "Micah Adams",
         description: "Front end development skills are becoming more essential as organizations continue to leverage platforms and infrastructures as services. This talk seeks to give developers with various levels of experience a perspective on where we have come so far, where we are going, and tools to navigate the new front end ecosystem.",
-        hasToggle: true
+        hasToggle: true,
+        icon: 'talk'
       },
       { time: "2.15PM - 2.45PM",
-        title: "ATOMIC DESIGN AS A MIGRATION STRATEGY",
-        speaker: "HARRISON HARNISCH",
+        title: "Atomic Design as a Migration Strategy",
+        speaker: "Harrison Harnisch",
         description: "Atomic design is well suited for migrating web applications. Because you build complexity out of simple components, you can start small and slowly carve out your application. I'd like to share how we're migrating 6 years of development at Buffer with Atomic Design.",
-        hasToggle: true
+        hasToggle: true,
+        icon: 'talk'
       },
       { time: "2.45PM - 3.15PM",
-        title: "ICE CREAM BREAK",
+        title: "Ice Cream Break",
         speaker: "",
         description: "",
-        hasToggle: false
+        hasToggle: false,
+        icon: 'pause'
       },
       { time: "3.15PM - 3.45PM",
-        title: "ALBERS AS A MILLENIAL",
-        speaker: "BILLY ROH",
+        title: "Albers as a Millenial",
+        speaker: "Billy Roh",
         description: "What kind of art would Josef and Anni Albers have made if they were millennials? Come learn about how to make generative interactive art with the magic of JavaScript. The audience will learn about applying colour theory with HSL, composing and generating your own patterns with SVG, and creating a sense of depth with motion and interaction.",
-        hasToggle: true
+        hasToggle: true,
+        icon: 'talk'
       },
       { time: "3.45PM - 4.15PM",
-        title: "CONVERSATIONAL ULS: TALKING TO SIRI, ALEXA, AND YOUR WEB BROWSER",
-        speaker: "SCOTT DAVIS",
+        title: "Conversational ULS: Talking to Siri, Alexa, and Your Web Browser",
+        speaker: "Scott Davis",
         description: "A typical user experience these days moves seamlessly between smartphones, tablets, laptops, and even smart TVs without us even thinking about it. But what if there is no screen? What if your User Interface is talking to your wrist, or talking to thin air as you walk into a room? Gartner predicts that 30% of all interactions with computers will be done with your voice by 2020. In this talk, [REDACTED] helps break down what Conversational UIs are, and how you can adopt them in your application.",
-        hasToggle: true
+        hasToggle: true,
+        icon: 'talk'
       },
       { time: "4.15PM - 4.35PM",
-        title: "BREAK",
+        title: "Break",
         speaker: "",
         description: "",
-        hasToggle: false
+        hasToggle: false,
+        icon: 'pause'
       },
       { time: "4.35PM - 4.45PM",
-        title: "ABOUT WORKSHOPS",
-        speaker: "STEVE KINNEY",
+        title: "About Workshops",
+        speaker: "Steve Kinney",
         description: "",
-        hasToggle: false
+        hasToggle: false,
+        icon: 'talk'
       },
       { time: "4.45PM - 5.15PM",
-        title: "THE TRUE COST OF UNMODERATED COLLABORATION: A STORY FROM THE TRENCHES",
-        speaker: "MYLES BORINS",
+        title: "The True Cost of Unmoderated Collaboration: A Story from the Trenches",
+        speaker: "Myles Borins",
         description: "Is your project prepared to deal with toxic behavior? What is your plan of action when members of your community are being harassed? Without a clear code-of-conduct and moderation guidelines you will likely spend more time discussing what to do than moderating. In the time that your projects leaders have spent coming to consensus, your community members are being attacked. While an individual leaving a project due to harassment is fairly hard to ignore, it is not as clear how many individuals decide not to get involved to avoid harassment and negative attention.",
-        hasToggle: true
+        hasToggle: true,
+        icon: 'talk'
       },
       { time: "5.15PM - 5.30PM",
-        title: "CLOSING NOTES",
+        title: "Closing Notes",
         speaker: "",
         description: "",
-        hasToggle: false
+        hasToggle: false,
+        icon: 'pause'
       },
+    ]);
+
+    controller.set('workshops', [
+      {
+        time: "9:00 AM - 12:00 PM",
+        title: "Machine Learning for Beginners",
+        speaker: "Rachel White",
+        description: "If you've ever wondered what cat you would be, you're in luck. Using Microsoft's Cognitive services Emotion Analysis API, we'll build a quick and easy to use node application that will analyze your selfies and let you know what purrfect feline suits your mood. Don't like cats? That's cool, swap out for your animal of choice.",
+        hasToggle: true,
+        icon: 'workshop'
+      },
+      {
+        time: "9:00 AM - 11:30 AM",
+        title: "Diversity, Inclusion, and Intersectionality",
+        speaker: "Patricia Realini",
+        description: "",
+        hasToggle: true,
+        icon: 'workshop'
+      },
+      {
+        time: "9:00 AM - 12:00 PM",
+        title: "Design for Developers (Or, How to Make Your Application Not Look Like Garbage)",
+        speaker: "Louisa Barrett",
+        description: "",
+        hasToggle: true,
+        icon: 'workshop'
+      },
+      {
+        time: "9:00 AM - 12:00 PM",
+        title: "TypeScript in Pracice",
+        speaker: "Bryan Hughes",
+        description: "Are you interested in TypeScript, but not sure where to start? Like most modern web development, it can feel like there are too many options and no obvious answers. This workshop will teach you all about TypeScript, and how to use it in practice. We'll walk through creating a small Node.js express app and a small React web app, all written in TypeScript. We'll also walk through setting up a build pipeline, and effectively debugging TypeScript code on the server and in the browser.",
+        hasToggle: true,
+        icon: 'workshop'
+      },
+      {
+        time: "12:30 PM - 4:30 PM",
+        title: "IoT and Serverless",
+        speaker: "Kas Perch",
+        description: "You've seen NodeBots, but how do you build systems with NodeBots? What systems would you build? In this workshop, we'll take a deeper dive into NodeBots (but we'll cover the basics in case you're new or it's been awhile). We'll talk about why serverless and IoT are best buddies, and discuss why and how you'd build a system of NodeBots devices.",
+        hasToggle: true,
+        icon: 'workshop'
+      },
+      {
+        time: "10:00 AM - 12:00 PM",
+        title: "Accessibility: The Basics and Beyond",
+        speaker: "Brian Sinclair",
+        description: "A lot of people talk about accessibility, but it's a very broad topic. Where does one even begin? In this workshop, we'll take a trip through the Web Content Accessibility Guidelines and talk about the most common places where applications fail to meet the standard. We'll also look at how quick and easy it is to take care of a lot of low-hanging fruit, as well as discuss some of the more complex aspects of what it means to be accessible.",
+        hasToggle: true,
+        icon: 'workshop'
+      },
+      {
+        time: "1:00 PM - 2:30 PM",
+        title: "Functional Programming with ClojureScript",
+        speaker: "Marla Brizel",
+        description: "Tired of fighting with state? (Don't worry, we all are.) Are you interested in learning the ins and outs of functional programming? Want to learn a new language to expand your horizons? Come learn how to write for the browser using ClojureScript—a Lisp-inspired language that compiles down to JavaScript and offers interoperability with browser APIs and existing client-side libraries. In this workshop, you'll learn how to write useful code in a functional language and how to apply these same concepts to your vanilla JavaScript.",
+        hasToggle: true,
+        icon: 'workshop'
+      },
+      {
+        time: "1:00 PM - 3:00 PM",
+        title: "Vue, I See You! Learning How to Build User Interfaces with a Progressive Framework",
+        speaker: "Regis Boudinot",
+        description: "Vue.js is a small progressive framework that is growing in popularity and in use! It is a nice mix of React and Angular (from a top level approach) and allows for a fun and fast development experience. It can also be incrementally adopted into existing codebases. This workshop will cover how to use the vue-cli and how to get a simple todo app running from scratch. I will cover how to use the reactive state Vue provides and live code with all of you so you can ask questions as I go along and we can learn together! I will also show examples of Vue in the wild (at GitLab) and how we have incrementally adopted it into our codebase.",
+        hasToggle: true,
+        icon: 'workshop'
+      },
+      {
+        time: "1:00 PM - 3:00 PM",
+        title: "Warning: May Cause Side Effects. How to Implement Redux Sagas as Middleware",
+        speaker: "Brenna Martenson",
+        description: "Redux has become the new hot tamale in making state management hurt less. Using pure functions called actions and reducers, Redux allows us to bridge the gap from a specific React component to that universal state. Although this has made front-end life easier, a remaining challenge is how to handle the events that need to happen in between the action and reducer. In this workshop we will talk about how Redux Sagas have stepped in to organize that stage of development using ES6 Generator functions.",
+        hasToggle: true,
+        icon: 'workshop'
+      }
     ]);
   }
 });

--- a/app/pods/seventeen/schedule/template.hbs
+++ b/app/pods/seventeen/schedule/template.hbs
@@ -1,0 +1,20 @@
+<div class="schedule">
+  <div class="padding--50 center-text white-border-bottom">
+    Schedule
+  </div>
+
+  <div class="schedule-wrap">
+    {{#each talks as |talk|}}
+      {{#seventeen-schedule-accordion time=talk.time title=talk.title hasToggle=talk.hasToggle classNames="schedule-item"}}
+        {{#if talk.speaker}}
+          <div class="schedule-speaker">{{talk.speaker}}</div>
+        {{/if}}
+        {{#if talk.description}}
+          <div class="schedule-description">{{talk.description}}</div>
+        {{/if}}
+      {{/seventeen-schedule-accordion}}
+    {{/each}}
+  </div>
+</div>
+
+{{outlet}}

--- a/app/pods/seventeen/schedule/template.hbs
+++ b/app/pods/seventeen/schedule/template.hbs
@@ -4,9 +4,10 @@
   </div>
 
   <div class="schedule-section-title">
-    <h3>June 15th Talks</h3>
-    <p>8AM - 5PM</p>
+    <h2>June 15th Talks</h2>
+    <h5>8AM - 5PM<br>
     <a href="https://www.google.com/maps/place/Space+Gallery/@39.7228828,-105.0005851,17z/data=!3m1!4b1!4m5!3m4!1s0x876c7f3037fba9d1:0x85b7cbb6aa50a36a!8m2!3d39.7228787!4d-104.9983911" target="_blank">Space Gallery</a>
+  </h5>
   </div>
 
   <div class="schedule-wrap">
@@ -20,9 +21,10 @@
   </div>
 
   <div class="schedule-section-title workshops">
-    <h3>June 16th WorkShops</h3>
-    <p>8AM - 5PM</p>
-    <a href=""  target="_blank">Galvanize</a>
+    <h2>June 16th Workshops</h2>
+    <h5>8AM - 5PM<br>
+    <!-- <a href=""  target="_blank">Galvanize</a> -->
+  </h5>
   </div>
 
   <div class="schedule-wrap">

--- a/app/pods/seventeen/schedule/template.hbs
+++ b/app/pods/seventeen/schedule/template.hbs
@@ -3,18 +3,39 @@
     Schedule
   </div>
 
+  <div class="schedule-section-title">
+    <h3>June 15th Talks</h3>
+    <p>8AM - 5PM</p>
+    <a href="https://www.google.com/maps/place/Space+Gallery/@39.7228828,-105.0005851,17z/data=!3m1!4b1!4m5!3m4!1s0x876c7f3037fba9d1:0x85b7cbb6aa50a36a!8m2!3d39.7228787!4d-104.9983911" target="_blank">Space Gallery</a>
+  </div>
+
   <div class="schedule-wrap">
     {{#each talks as |talk|}}
-      {{#seventeen-schedule-accordion time=talk.time title=talk.title hasToggle=talk.hasToggle classNames="schedule-item"}}
-        {{#if talk.speaker}}
-          <div class="schedule-speaker">{{talk.speaker}}</div>
-        {{/if}}
+      {{#seventeen-schedule-accordion time=talk.time title=talk.title icon=talk.icon hasToggle=talk.hasToggle speaker=talk.speaker classNames="schedule-item"}}
         {{#if talk.description}}
           <div class="schedule-description">{{talk.description}}</div>
         {{/if}}
       {{/seventeen-schedule-accordion}}
     {{/each}}
   </div>
+
+  <div class="schedule-section-title workshops">
+    <h3>June 16th WorkShops</h3>
+    <p>8AM - 5PM</p>
+    <a href=""  target="_blank">Galvanize</a>
+  </div>
+
+  <div class="schedule-wrap">
+    {{#each workshops as |shop|}}
+      {{#seventeen-schedule-accordion time=shop.time title=shop.title hasToggle=shop.hasToggle icon=shop.icon speaker=shop.speaker classNames="schedule-item"}}
+      <i>{{icon-library shop.icon}}</i>
+        {{#if shop.description}}
+          <div class="schedule-description">{{shop.description}}</div>
+        {{/if}}
+      {{/seventeen-schedule-accordion}}
+    {{/each}}
+  </div>
+
 </div>
 
 {{outlet}}

--- a/app/router.js
+++ b/app/router.js
@@ -18,6 +18,7 @@ Router.map(function() {
     this.route('speakers');
     this.route('attend');
     this.route('team');
+    this.route('schedule');
   });
 });
 

--- a/app/styles/css/_grid.scss
+++ b/app/styles/css/_grid.scss
@@ -2,6 +2,10 @@
   display: flex;
 }
 
+.flex-grid {
+  display: flex;
+}
+
 .box__1 {
   flex: 1;
 }

--- a/app/styles/pages/_schedule.scss
+++ b/app/styles/pages/_schedule.scss
@@ -11,7 +11,7 @@
   }
 
   .schedule-wrap {
-    width: 90%;
+    width: 95%;
     max-width: 1800px;
     margin: 0 auto;
   }
@@ -38,7 +38,7 @@
     overflow: hidden;
     transition: 300ms ease-in-out;
     height: auto;
-    border-top: 1px solid white;
+    box-shadow: inset 0 1px 0 0px white;
 
     &.hidden {
       max-height: 0;
@@ -54,8 +54,11 @@
   }
 
   .schedule-description {
-    width: 50%;
+    max-width: 700px;
     padding: 50px;
+    border-right: 1px solid;
+    margin: 0 auto;
+    border-left: 1px solid;
   }
 
   .schedule-time {
@@ -67,7 +70,7 @@
   }
 
   .schedule-title,  {
-    font-weight: bold;
+    font-weight: normal;
     text-align: right;
     p {
       margin-bottom: 0;
@@ -83,6 +86,10 @@
     padding: 60px;
     border-bottom: 1px solid white;
 
+    h2 {
+      margin-bottom: 0;
+    }
+
     &.workshops {
       border-top: 1px solid white;
     }
@@ -93,14 +100,20 @@
     margin-right: 30px;
     height: 20px;
     width: 15px;
+    margin-top: 2px;
     vertical-align: sub;
 
     &.talk {
       width: 21px;
     }
 
+    &.pause {
+      width: 12px;
+    }
+
     &.workshop {
-      width: 10px;
+      width: 8px;
+      margin-top: 3px;
     }
 
     svg {
@@ -119,6 +132,7 @@
     }
   }
 }
+
 
 .schedule {
 
@@ -190,5 +204,36 @@
 
   hr {
     background-color: $color_grey;
+  }
+}
+
+
+@media only screen and (max-width: 750px) {
+  .seventeen .schedule-description {
+    border: 0;
+    padding: 30px;
+    font-size: 15px;
+  }
+
+  .seventeen .schedule-time {
+    font-size: 22px;
+    margin-bottom: 8px;
+  }
+
+  .seventeen .schedule-title h5 {
+    font-size: 22px;
+    margin-top: 8px;
+  }
+
+  .seventeen .schedule-title-bar {
+    padding: 20px 20px 40px;
+  }
+
+  .seventeen .schedule-section-title {
+    padding: 60px 20px;
+  }
+
+  .seventeen .schedule-section-title h2 {
+    font-size: 2rem;
   }
 }

--- a/app/styles/pages/_schedule.scss
+++ b/app/styles/pages/_schedule.scss
@@ -2,6 +2,84 @@
   opacity: 0.4;
 }
 
+.seventeen {
+  &.seventeen-schedule {
+    background: $color_gray_blue;
+    .seventeen {
+      background: $color_gray_blue;
+    }
+  }
+
+  .schedule-wrap {
+    width: 90%;
+    max-width: 1800px;
+    margin: 0 auto;
+  }
+
+  .not-toggleable {
+    cursor: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABsAAAAeCAYAAADdGWXmAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAPFJREFUeNrkloENhCAMRcEJGKGjMAIjOIIj3CaM4G1wI7jCbeAIXElKjiiIB+ViYpMGg8Dv+2qjEFcI55zCnDDhH2Kj+8bSVRgPnknEYhoaV3ZhstAHkABE9wwVwkNMFs50/fBUmYLGZmHc8PIHbSkLTqSEVUkIaIOK5myK7qSwH01u8RQsTBQAFc/eC+vcgiVYuJk/TXe2kp2FrXRHYjsLu9HlLGSnO7KQna5kIStdyUI2utADKyyHWgvtj3vq6MhCU/lCQTcLm+iof+nGz6X/r0OXnnl7urXU6gYOMSnlG4cn5nQZuoFLLKLT4nbxEWAA4a/rQvlXHjsAAAAASUVORK5CYII=), auto !important;
+  }
+
+  .toggleable {
+    cursor: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABsAAAAeCAYAAADdGWXmAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAEZJREFUeNpiYBjs4P///w70tOw/OfqY6Bkio5aNWjZq2ahl5AMWaKFKcsEK1NdAopYHdPXZaKk/atmoZaOWjVo2kgBAgAEAfKUTQkAdP+0AAAAASUVORK5CYII=), auto !important;
+  }
+
+  .schedule-item {
+    border-right: 1px solid $color_white;
+    border-left: 1px solid $color_white;
+    border-bottom: 1px solid $color_white;
+    padding: 50px;
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  .schedule-accordion-content {
+    overflow: hidden;
+    transition: 300ms ease-in-out;
+    height: auto;
+
+    &.hidden {
+      max-height: 0
+    }
+
+    &.showing {
+      max-height: 500px;
+    }
+  }
+
+  .schedule-time {
+    left: 0;
+  }
+
+  .schedule-padding-wrap {
+    position: relative;
+  }
+
+  .schedule-title,  {
+    position: absolute;
+    right: 0px;
+    font-weight: bold;
+  }
+
+  .schedule-time, .schedule-title {
+    display: inline-block;
+  }
+
+  .schedule-time, .schedule-title, .schedule-accordion-content {
+    text-transform: uppercase;
+  }
+
+  @media only screen and ( max-width: $break_tablet_medium ) {
+    .schedule-time, .schedule-title, .schedule-accordion-content {
+      position: relative;
+      display: inherit;
+      text-align: center;
+      width: 100%;
+    }
+  }
+}
+
 .schedule {
 
   .schedule__row {
@@ -10,7 +88,7 @@
   }
 
   .schedule__row-time {
-    color: white;
+    color: $color_white;
     opacity: 0.4;
     justify-content: flex-start;
     width: 40%;

--- a/app/styles/pages/_schedule.scss
+++ b/app/styles/pages/_schedule.scss
@@ -28,7 +28,7 @@
     border-right: 1px solid $color_white;
     border-left: 1px solid $color_white;
     border-bottom: 1px solid $color_white;
-    padding: 50px;
+    // padding: 50px;
     &:last-child {
       border-bottom: none;
     }
@@ -38,14 +38,24 @@
     overflow: hidden;
     transition: 300ms ease-in-out;
     height: auto;
+    border-top: 1px solid white;
 
     &.hidden {
-      max-height: 0
+      max-height: 0;
     }
 
     &.showing {
       max-height: 500px;
     }
+  }
+
+  .schedule-title-bar {
+    padding: 50px;
+  }
+
+  .schedule-description {
+    width: 50%;
+    padding: 50px;
   }
 
   .schedule-time {
@@ -57,17 +67,47 @@
   }
 
   .schedule-title,  {
-    position: absolute;
-    right: 0px;
     font-weight: bold;
+    text-align: right;
+    p {
+      margin-bottom: 0;
+    }
   }
 
   .schedule-time, .schedule-title {
     display: inline-block;
   }
 
-  .schedule-time, .schedule-title, .schedule-accordion-content {
-    text-transform: uppercase;
+  .schedule-section-title {
+    text-align: center;
+    padding: 60px;
+    border-bottom: 1px solid white;
+
+    &.workshops {
+      border-top: 1px solid white;
+    }
+  }
+
+  .schedule-icon {
+    display: inline-block;
+    margin-right: 30px;
+    height: 20px;
+    width: 15px;
+    vertical-align: sub;
+
+    &.talk {
+      width: 21px;
+    }
+
+    &.workshop {
+      width: 10px;
+    }
+
+    svg {
+      width: 100%;
+      height: auto;
+    }
+
   }
 
   @media only screen and ( max-width: $break_tablet_medium ) {

--- a/tests/integration/pods/components/seventeen-schedule-accordion/component-test.js
+++ b/tests/integration/pods/components/seventeen-schedule-accordion/component-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('seventeen-schedule-accordion', 'Integration | Component | seventeen schedule accordion', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{seventeen-schedule-accordion}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#seventeen-schedule-accordion}}
+      template block text
+    {{/seventeen-schedule-accordion}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/unit/helpers/icon-library-test.js
+++ b/tests/unit/helpers/icon-library-test.js
@@ -1,0 +1,10 @@
+import { iconLibrary } from 'dinosaurjs/helpers/icon-library';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | icon library');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = iconLibrary([42]);
+  assert.ok(result);
+});

--- a/tests/unit/pods/seventeen/schedule/route-test.js
+++ b/tests/unit/pods/seventeen/schedule/route-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:seventeen/schedule', 'Unit | Route | seventeen/schedule', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
#### What does this do?
This adds the 2017 dinojs schedule page. It should have all the current schedule items detailed out in the google doc (and descriptions from the speakers page).

#### HOWEVER
HOWEVER!! there were speakers on the speakers page that were not in the google doc and so were not added to the schedule, there is one talk without a title,  there was at least one speaker with a different name spelling between the google doc and the speaker page, and I put no toggle/description to the non talk events (BREAK, LUNCH, etc) and just went with the title for each as was listed in the doc. These are all easy to edit so just let me know.